### PR TITLE
Integrate Codecov with minimum test coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%


### PR DESCRIPTION
Related to #37

Integrates Codecov with a minimum test coverage threshold and updates CI/CD pipeline.
- Adds a new `codecov.yml` configuration file setting the minimum project and patch coverage target to 80% and the threshold for coverage decrease to 1%.