### PR TITLE
Fix SLSA builds configuration

### DIFF
--- a/.github/workflows/slsa.yaml
+++ b/.github/workflows/slsa.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      actions: read
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
     with:
       go-version: 1.22


### PR DESCRIPTION
Related to #36

Updates the `.github/workflows/slsa.yaml` to fix the SLSA build issue by adjusting permissions.
- Adds `actions: read` permission to the `build` job to resolve the invalid workflow file error related to 'actions: read' permissions.