### PR TITLE
Add gcp workload identity federation

### DIFF
--- a/.github/workflows/uds-scan.yaml
+++ b/.github/workflows/uds-scan.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   scan:
@@ -15,6 +16,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v2
+
+      - uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2
+        with:
+          workload_identity_provider: "${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
+          project_id: "${{ secrets.GCP_PROJECT }}"
 
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2

--- a/internal/sql/connection.go
+++ b/internal/sql/connection.go
@@ -50,13 +50,13 @@ type CloudSQLConnector struct {
 
 // Connect connects to the database using the Cloud SQL connection.
 func (c *CloudSQLConnector) Connect(ctx context.Context) (*gorm.DB, error) {
-	dialer, err := cloudsqlconn.NewDialer(ctx)
+	dialer, err := cloudsqlconn.NewDialer(ctx, cloudsqlconn.WithIAMAuthN())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dialer: %w", err)
 	}
 
-	config, err := pgxpool.ParseConfig(fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable",
-		c.user, c.password, c.dbname))
+	config, err := pgxpool.ParseConfig(fmt.Sprintf("user=%s dbname=%s sslmode=disable",
+		c.user, c.dbname))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse configuration: %w", err)
 	}


### PR DESCRIPTION
This PR adds the initial step for GCP Workload Identity Federation.

I have created the pool, provider, and principal set in the GCP project and setup access to the Cloud SQL instance. I've also add the secrets to the GHA settings for the repo.

Remaining work is to refactor the sql connector [here](https://github.com/defenseunicorns/uds-security-hub/blob/d31d6a8763f325338a2351d8c2a81df6f8decacc/internal/sql/connection.go#L52) to be IAM aware per [the docs](https://cloud.google.com/sql/docs/mysql/iam-logins#go) and drop the provisioned database credentials.

@naveensrinivasan you can push to my branch here with those changes when you're ready or we can pair on it.