### PR TITLE
configure goreleaser for SBOMs for issue #109

### DIFF
--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -25,6 +25,10 @@ jobs:
         go-version: '1.22.4'
         check-latest: true
 
+    - name: Install syft
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
     - name: Create temporary Git tag
       run: |
         git tag v0.0.0-temp-tag

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,4 +29,6 @@ checksum:
 release:
   draft: true
 sboms:
-  - artifacts: archive
+  - artifacts: binary
+    documents:
+      - "{{ .Binary }}_{{ .Os }}_{{ .Arch }}.spdx.sbom.json"


### PR DESCRIPTION
- configure it to run syft against the generated binaries
- update the naming pattern to match the binaries generated

Here is an example release generated on my fork:
https://github.com/partkyle/uds-security-hub/releases/tag/untagged-9c0391ef858adafde169


Solves issue #109 