### PR TITLE
configure goreleaser for SBOMs

### DIFF
--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -25,6 +25,10 @@ jobs:
         go-version: '1.22.4'
         check-latest: true
 
+    - name: Install syft
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
     - name: Create temporary Git tag
       run: |
         git tag v0.0.0-temp-tag

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Install syft
       uses: anchore/sbom-action/download-syft@v0
+      with:
+        syft-version: v1.9.0
 
     - name: Create temporary Git tag
       run: |

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -26,8 +26,7 @@ jobs:
         check-latest: true
 
     - name: Install syft
-      run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+      uses: anchore/sbom-action/download-syft@v0
 
     - name: Create temporary Git tag
       run: |

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -26,7 +26,7 @@ jobs:
         check-latest: true
 
     - name: Install syft
-      uses: anchore/sbom-action/download-syft@v0
+      uses: anchore/sbom-action/download-syft@f2d02cbcc3489818621f2809e6cae4ce98b19c27 # v0
       with:
         syft-version: v1.9.0
 

--- a/.github/workflows/osv.yml
+++ b/.github/workflows/osv.yml
@@ -12,6 +12,8 @@ permissions:
   security-events: write
   # Only need to read contents
   contents: read
+  # needs to read actions
+  actions: read
 
 jobs:
   scan-pr:

--- a/.github/workflows/slsa.yaml
+++ b/.github/workflows/slsa.yaml
@@ -36,6 +36,10 @@ jobs:
         with:
           go-version: 1.22.4
           check-latest: true
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@f2d02cbcc3489818621f2809e6cae4ce98b19c27 # v0
+        with:
+          syft-version: v1.9.0
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,4 +29,6 @@ checksum:
 release:
   draft: true
 sboms:
-  - artifacts: archive
+  - artifacts: binary
+    documents:
+      - "{{ .Binary }}_{{ .Os }}_{{ .Arch }}.spdx.sbom.json"


### PR DESCRIPTION
- configure it to run syft against the generated binaries
- update the naming pattern to match the binaries generated
- install syft in the goreleaser github action
- Fixes #109 