### PR TITLE
Update OSV-Scanner workflow permissions and job reference

### DIFF
--- a/.github/workflows/osv-schedule.yml
+++ b/.github/workflows/osv-schedule.yml
@@ -11,6 +11,8 @@ permissions:
   security-events: write
   # Only need to read contents
   contents: read
+  # Add actions read permission
+  actions: read
 
 jobs:
   scan-scheduled:


### PR DESCRIPTION
- Added `actions: read` permission to the workflow to ensure proper access.
- https://github.com/defenseunicorns/uds-security-hub/actions/runs/10353887588

This change ensures the workflow has the necessary permissions and uses the correct reusable workflow version.