### PR TITLE
Add JSON Output Support for Scan Results

### DIFF
--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -109,14 +109,13 @@ func TestScanImageE2E(t *testing.T) {
 		t.Fatalf("Expected non-empty vulnerabilities, got empty")
 	}
 	var buf bytes.Buffer
-	if err := reader.WriteToJSON(&buf); err != nil {
+	if err := WriteToJSON(&buf, []types.ScanResultReader{reader}); err != nil {
 		t.Fatalf("Error writing JSON: %v", err)
 	}
 	jsonOutput := buf.String()
 	if jsonOutput == "" {
 		t.Fatalf("Expected non-empty JSON, got empty")
 	}
-
 	buf.Reset() // Reset buffer for CSV writing
 
 	if err := reader.WriteToCSV(&buf, true); err != nil {

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -109,11 +109,21 @@ func TestScanImageE2E(t *testing.T) {
 		t.Fatalf("Expected non-empty vulnerabilities, got empty")
 	}
 	var buf bytes.Buffer
-	if err := reader.WriteToCSV(&buf, true); err != nil {
-		t.Fatalf("Error writing csv: %v", err)
+	if err := reader.WriteToJSON(&buf); err != nil {
+		t.Fatalf("Error writing JSON: %v", err)
 	}
-	csv := buf.String()
-	if csv == "" {
+	jsonOutput := buf.String()
+	if jsonOutput == "" {
+		t.Fatalf("Expected non-empty JSON, got empty")
+	}
+
+	buf.Reset() // Reset buffer for CSV writing
+
+	if err := reader.WriteToCSV(&buf, true); err != nil {
+		t.Fatalf("Error writing CSV: %v", err)
+	}
+	csvOutput := buf.String()
+	if csvOutput == "" {
 		t.Fatalf("Expected non-empty CSV, got empty")
 	}
 }

--- a/pkg/scan/scan_result_reader.go
+++ b/pkg/scan/scan_result_reader.go
@@ -71,25 +71,26 @@ func (s *scanResultReader) WriteToCSV(w io.Writer, includeHeader bool) error {
 	return nil
 }
 
-// WriteToJSON writes the scan results to the provided writer in JSON format.
-func (s *scanResultReader) WriteToJSON(w io.Writer) error {
-	vulnerabilities := s.GetVulnerabilities()
-	data := []map[string]string{}
+func WriteToJSON(w io.Writer, results []types.ScanResultReader) error {
+	var allResults []map[string]string
 
-	for _, vuln := range vulnerabilities {
-		record := map[string]string{
-			"ArtifactName":     s.GetArtifactName(),
-			"VulnerabilityID":  vuln.VulnerabilityID,
-			"PkgName":          vuln.PkgName,
-			"InstalledVersion": vuln.InstalledVersion,
-			"FixedVersion":     vuln.FixedVersion,
-			"Severity":         vuln.Severity,
-			"Description":      vuln.Description,
+	for _, r := range results {
+		vulnerabilities := r.GetVulnerabilities()
+		for _, vuln := range vulnerabilities {
+			record := map[string]string{
+				"ArtifactName":     r.GetArtifactName(),
+				"VulnerabilityID":  vuln.VulnerabilityID,
+				"PkgName":          vuln.PkgName,
+				"InstalledVersion": vuln.InstalledVersion,
+				"FixedVersion":     vuln.FixedVersion,
+				"Severity":         vuln.Severity,
+				"Description":      vuln.Description,
+			}
+			allResults = append(allResults, record)
 		}
-		data = append(data, record)
 	}
 
-	jsonData, err := json.MarshalIndent(data, "", "  ")
+	jsonData, err := json.MarshalIndent(allResults, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling scan results to JSON: %w", err)
 	}

--- a/pkg/scan/scan_result_reader_test.go
+++ b/pkg/scan/scan_result_reader_test.go
@@ -1,0 +1,55 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/defenseunicorns/uds-security-hub/pkg/types"
+)
+
+func TestWriteToJSON(t *testing.T) {
+	scanResult := types.ScanResult{
+		ArtifactName: "test-artifact",
+		Results: []struct {
+			Vulnerabilities []types.VulnerabilityInfo `json:"Vulnerabilities"`
+		}{
+			{
+				Vulnerabilities: []types.VulnerabilityInfo{
+					{
+						VulnerabilityID:  "CVE-2021-1234",
+						PkgName:          "test-package",
+						InstalledVersion: "1.0.0",
+						FixedVersion:     "1.0.1",
+						Severity:         "HIGH",
+						Description:      "Test vulnerability",
+					},
+				},
+			},
+		},
+	}
+
+	reader := scanResultReader{
+		scanResult: scanResult,
+	}
+
+	var buf bytes.Buffer
+	err := reader.WriteToJSON(&buf)
+	require.NoError(t, err)
+
+	var output []map[string]string
+	err = json.Unmarshal(buf.Bytes(), &output)
+	require.NoError(t, err)
+
+	require.Len(t, output, 1)
+	assert.Equal(t, "test-artifact", output[0]["ArtifactName"])
+	assert.Equal(t, "CVE-2021-1234", output[0]["VulnerabilityID"])
+	assert.Equal(t, "test-package", output[0]["PkgName"])
+	assert.Equal(t, "1.0.0", output[0]["InstalledVersion"])
+	assert.Equal(t, "1.0.1", output[0]["FixedVersion"])
+	assert.Equal(t, "HIGH", output[0]["Severity"])
+	assert.Equal(t, "Test vulnerability", output[0]["Description"])
+}

--- a/pkg/types/scan.go
+++ b/pkg/types/scan.go
@@ -34,9 +34,6 @@ type ScanResultReader interface {
 
 	// WriteToCSV writes the results to the provided reader in CSV format.
 	WriteToCSV(w io.Writer, includeHeader bool) error
-
-	// WriteToJSON writes the results to the provided reader in JSON format.
-	WriteToJSON(w io.Writer) error
 }
 
 type PackageScannerResult struct {

--- a/pkg/types/scan.go
+++ b/pkg/types/scan.go
@@ -34,6 +34,9 @@ type ScanResultReader interface {
 
 	// WriteToCSV writes the results to the provided reader in CSV format.
 	WriteToCSV(w io.Writer, includeHeader bool) error
+
+	// WriteToJSON writes the results to the provided reader in JSON format.
+	WriteToJSON(w io.Writer) error
 }
 
 type PackageScannerResult struct {


### PR DESCRIPTION
This commit introduces the ability to output scan results in JSON and CSV formats. 

The following changes were made:

1. **Command Line Interface (CLI) Enhancements:**
   - A new persistent flag, `--output-format,` was added to specify the desired output format (`csv` or `json`).
   - Updated the `runScanner` function to handle the new `--output-format` flag and write the scan results accordingly.

2. **Test Enhancements:**
   - Updated `TestScanImageE2E` to test both JSON and CSV output formats.
   - Added checks to ensure non-empty JSON output.

3. **Scan Result Reader Enhancements:**
   - Implemented the `WriteToJSON` method in `scanResultReader` to serialize scan results into JSON format.
   - Updated the `ScanResultReader` interface to include the new `WriteToJSON` method.

4. **Error Handling Improvements:**
   - Enhanced error messages to be more descriptive, especially when creating output files and writing scan results.

5. **Miscellaneous:**
   - Minor refactoring for consistency and readability.

These changes improve the scanning tool's flexibility and usability by allowing users to choose their preferred output format. This makes integrating with various workflows and tools that consume JSON data easier.

Files Modified:
- `cmd/scan.go`
- `pkg/scan/local_scan_test.go`
- `pkg/scan/scan_result_reader.go`
- `pkg/types/scan.go`

## Example JSON output
<details>
  <summary>Click to expand JSON!</summary>

```json
[
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "Curl_smtp_escape_eob in lib/smtp.c in curl 7.54.1 to and including curl 7.60.0 has a heap-based buffer overflow that might be exploitable by an attacker who can control the data that curl transmits over SMTP with certain settings (i.e., use of a nonstandard --limit-rate argument or CURLOPT_BUFFERSIZE value).",
    "FixedVersion": "7.61.0-r0",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-0500"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "curl version curl 7.54.1 to and including curl 7.59.0 contains a CWE-122: Heap-based Buffer Overflow vulnerability in denial of service and more that can result in curl might overflow a heap based memory buffer when closing down an FTP connection with very long server command replies.. This vulnerability appears to have been fixed in curl < 7.54.1 and curl >= 7.60.0.",
    "FixedVersion": "7.60.0-r0",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-1000300"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "curl version curl 7.20.0 to and including curl 7.59.0 contains a CWE-126: Buffer Over-read vulnerability in denial of service that can result in curl can be tricked into reading data beyond the end of a heap based buffer used to store downloaded RTSP content.. This vulnerability appears to have been fixed in curl < 7.20.0 and curl >= 7.60.0.",
    "FixedVersion": "7.60.0-r0",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-1000301"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "curl before version 7.61.1 is vulnerable to a buffer overrun in the NTLM authentication code. The internal function Curl_ntlm_core_mk_nt_hash multiplies the length of the password by two (SUM) to figure out how large temporary storage area to allocate from the heap. The length value is then subsequently used to iterate over the password and generate output into the allocated storage buffer. On systems with a 32 bit size_t, the math to calculate SUM triggers an integer overflow when the password length exceeds 2GB (2^31 bytes). This integer overflow usually causes a very small buffer to actually get allocated instead of the intended very huge one, making the use of that buffer end up in a heap buffer overflow. (This bug is almost identical to CVE-2017-8816.)",
    "FixedVersion": "7.61.1-r0",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-14618"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "Curl versions 7.33.0 through 7.61.1 are vulnerable to a buffer overrun in the SASL authentication code that may lead to denial of service.",
    "FixedVersion": "7.61.1-r1",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-16839"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "A heap use-after-free flaw was found in curl versions from 7.59.0 through 7.61.1 in the code related to closing an easy handle. When closing and cleaning up an 'easy' handle in the `Curl_close()` function, the library code first frees a struct (without nulling the pointer) and might then subsequently erroneously write to a struct field within that already freed struct.",
    "FixedVersion": "7.61.1-r1",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-16840"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "Curl versions 7.14.1 through 7.61.1 are vulnerable to a heap-based buffer over-read in the tool_msgs.c:voutf() function that may result in information exposure and denial of service.",
    "FixedVersion": "7.61.1-r1",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2018-16842"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "libcurl versions from 7.36.0 to before 7.64.0 are vulnerable to a stack-based buffer overflow. The function creating an outgoing NTLM type-3 header (`lib/vauth/ntlm.c:Curl_auth_create_ntlm_type3_message()`), generates the request HTTP header contents based on previously received data. The check that exists to prevent the local buffer from getting overflowed is implemented wrongly (using unsigned math) and as such it does not prevent the overflow from happening. This output data can grow larger than the local buffer if very large 'nt response' data is extracted from a previous NTLMv2 header provided by the malicious or broken HTTP server. Such a 'large value' needs to be around 1000 bytes or more. The actual payload data copied to the target buffer comes from the NTLMv2 type-2 response header.",
    "FixedVersion": "7.61.1-r2",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2019-3822"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "Double-free vulnerability in the FTP-kerberos code in cURL 7.52.0 to 7.65.3.",
    "FixedVersion": "7.61.1-r3",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2019-5481"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "Heap buffer overflow in the TFTP protocol handler in cURL 7.19.4 to 7.65.3.",
    "FixedVersion": "7.61.1-r3",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2019-5482"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "libcurl versions from 7.36.0 to before 7.64.0 is vulnerable to a heap buffer out-of-bounds read. The function handling incoming NTLM type-2 messages (`lib/vauth/ntlm.c:ntlm_decode_type2_target`) does not validate incoming data correctly and is subject to an integer overflow vulnerability. Using that overflow, a malicious or broken NTLM server could trick libcurl to accept a bad length + offset combination that would lead to a buffer read out-of-bounds.",
    "FixedVersion": "7.61.1-r2",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "HIGH",
    "VulnerabilityID": "CVE-2018-16890"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "libcurl versions from 7.34.0 to before 7.64.0 are vulnerable to a heap out-of-bounds read in the code handling the end-of-response for SMTP. If the buffer passed to `smtp_endofresp()` isn't NUL terminated and contains no character ending the parsed number, and `len` is set to 5, then the `strtol()` call reads beyond the allocated buffer. The read contents will not be returned to the caller.",
    "FixedVersion": "7.61.1-r2",
    "InstalledVersion": "7.59.0-r0",
    "PkgName": "curl",
    "Severity": "HIGH",
    "VulnerabilityID": "CVE-2019-3823"
  },
  {
    "ArtifactName": "docker.io/appropriate/curl:latest",
    "Description": "musl libc through 1.1.23 has an x87 floating-point stack adjustment imbalance, related to the math/i386/ directory. In some cases, use of this library could introduce out-of-bounds writes that are not present in an application's source code.",
    "FixedVersion": "1.1.18-r4",
    "InstalledVersion": "1.1.18-r2",
    "PkgName": "musl",
    "Severity": "CRITICAL",
    "VulnerabilityID": "CVE-2019-14697"
  }
]

```
</details>

Fixes #141 