### PR TITLE
create output directory if it does not exist

### DIFF
--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -145,7 +145,6 @@ func TestScanImageE2E(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func checkError(t *testing.T, err error, expectError bool) {

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -88,43 +88,64 @@ func TestScanImageE2E(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewLogger(ctx)
 
-	lps, err := NewLocalPackageScanner(logger, zarfPackagePath, "", true)
-	if err != nil {
-		t.Fatalf("Failed to create local package scanner: %v", err)
+	type testCase struct {
+		name string
+		sbom bool
 	}
-	result, err := lps.Scan(ctx)
-	if err != nil {
-		t.Fatalf("Failed to scan image: %v", err)
-	}
-	reader, err := lps.ScanResultReader(result[0])
-	if err != nil {
-		t.Fatalf("Failed to get scan result reader: %v", err)
-	}
-	artifactName := reader.GetArtifactName()
-	if artifactName == "" {
-		t.Fatalf("Expected artifact name to be non-empty, got %s", artifactName)
-	}
-	vulnerabilities := reader.GetVulnerabilities()
-	if len(vulnerabilities) == 0 {
-		t.Fatalf("Expected non-empty vulnerabilities, got empty")
-	}
-	var buf bytes.Buffer
-	if err := WriteToJSON(&buf, []types.ScanResultReader{reader}); err != nil {
-		t.Fatalf("Error writing JSON: %v", err)
-	}
-	jsonOutput := buf.String()
-	if jsonOutput == "" {
-		t.Fatalf("Expected non-empty JSON, got empty")
-	}
-	buf.Reset() // Reset buffer for CSV writing
 
-	if err := reader.WriteToCSV(&buf, true); err != nil {
-		t.Fatalf("Error writing CSV: %v", err)
+	testCases := []testCase{
+		{
+			name: "sbom",
+			sbom: true,
+		},
+		{
+			name: "rootfs",
+			sbom: false,
+		},
 	}
-	csvOutput := buf.String()
-	if csvOutput == "" {
-		t.Fatalf("Expected non-empty CSV, got empty")
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			lps, err := NewLocalPackageScanner(logger, zarfPackagePath, "", tt.sbom)
+			if err != nil {
+				t.Fatalf("Failed to create local package scanner: %v", err)
+			}
+			result, err := lps.Scan(ctx)
+			if err != nil {
+				t.Fatalf("Failed to scan image: %v", err)
+			}
+			reader, err := lps.ScanResultReader(result[0])
+			if err != nil {
+				t.Fatalf("Failed to get scan result reader: %v", err)
+			}
+			artifactName := reader.GetArtifactName()
+			if artifactName == "" {
+				t.Fatalf("Expected artifact name to be non-empty, got %s", artifactName)
+			}
+			vulnerabilities := reader.GetVulnerabilities()
+			if len(vulnerabilities) == 0 {
+				t.Fatalf("Expected non-empty vulnerabilities, got empty")
+			}
+			var buf bytes.Buffer
+			if err := WriteToJSON(&buf, []types.ScanResultReader{reader}); err != nil {
+				t.Fatalf("Error writing JSON: %v", err)
+			}
+			jsonOutput := buf.String()
+			if jsonOutput == "" {
+				t.Fatalf("Expected non-empty JSON, got empty")
+			}
+			buf.Reset() // Reset buffer for CSV writing
+
+			if err := reader.WriteToCSV(&buf, true); err != nil {
+				t.Fatalf("Error writing CSV: %v", err)
+			}
+			csvOutput := buf.String()
+			if csvOutput == "" {
+				t.Fatalf("Expected non-empty CSV, got empty")
+			}
+		})
 	}
+
 }
 
 func checkError(t *testing.T, err error, expectError bool) {

--- a/pkg/scan/rootfs.go
+++ b/pkg/scan/rootfs.go
@@ -29,6 +29,14 @@ func sanitizeArchivePath(dir, filename string) (v string, err error) {
 func extractTarToDir(outDir string, r io.Reader) error {
 	tarReader := tar.NewReader(r)
 
+	_, err := os.Stat(outDir)
+	if errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(outDir, 0o700)
+		if err != nil {
+			return fmt.Errorf("failed to create output dir and it was not created beforehand: %w", err)
+		}
+	}
+
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {


### PR DESCRIPTION
There is a edgecase where some packages have layers that don't have a root directory, and they won't hit the `os.MkdirAll` before they try to write files. 

This checks for the output dir to see if it exists, and if it doesn't it tries to create it.

This fixes issues with the sonarqube package locally.

This also addresses a missing test for local rootfs tests.