### PR TITLE
[experimental] add image scanner

### DIFF
--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -44,7 +44,7 @@ var errFlagRetrieval = errors.New("error getting flag")
 var errRequiredFlagEmpty = errors.New("is required and cannot be empty")
 
 func newStoreCmd() *cobra.Command {
-	var storeCmd = &cobra.Command{
+	storeCmd := &cobra.Command{
 		Use:   "store",
 		Short: "Scan a Zarf package and store the results in the database",
 		Long:  "Scan a Zarf package for vulnerabilities and store the results in the database using GormScanManager",
@@ -125,7 +125,7 @@ func runStoreScanner(cmd *cobra.Command, _ []string) error {
 	}
 	parsedCreds := docker.ParseCredentials(registryCreds)
 	scanner := scan.NewRemotePackageScanner(ctx, logInstance, config.Org, config.PackageName,
-		config.Tag, config.OfflineDBPath, parsedCreds, false)
+		config.Tag, config.OfflineDBPath, parsedCreds, scan.RootFSScannerType)
 	manager, err := db.NewGormScanManager(config.DBConn)
 	if err != nil {
 		return fmt.Errorf("error initializing GormScanManager: %w", err)

--- a/pkg/scan/e2e_test.go
+++ b/pkg/scan/e2e_test.go
@@ -17,11 +17,12 @@ func TestE2EScanFunctionality(t *testing.T) {
 		t.Skip("Skipping integration test")
 	}
 	testCases := []struct {
-		name string
-		sbom bool
+		name        string
+		scannerType ScannerType
 	}{
-		{name: "RootFS Scanner", sbom: false},
-		{name: "SBOM Scanner", sbom: true},
+		{name: "SBOM Scanner", scannerType: SBOMScannerType},
+		{name: "RootFS Scanner", scannerType: RootFSScannerType},
+		{name: "Image Scanner", scannerType: ImageScannerType},
 	}
 
 	for _, tt := range testCases {
@@ -40,7 +41,7 @@ func TestE2EScanFunctionality(t *testing.T) {
 			packageName := "packages/uds/sonarqube"
 			tag := "9.9.5-uds.1-upstream"
 			// Create the scanner
-			scanner := NewRemotePackageScanner(ctx, logger, org, packageName, tag, "", registryCreds, tt.sbom)
+			scanner := NewRemotePackageScanner(ctx, logger, org, packageName, tag, "", registryCreds, tt.scannerType)
 			// Perform the scan
 			results, err := scanner.Scan(ctx)
 			if err != nil {

--- a/pkg/scan/image.go
+++ b/pkg/scan/image.go
@@ -1,0 +1,36 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func findImageIndexScannables(ociRootDir string) ([]trivyScannable, error) {
+	indexFilename := path.Join(ociRootDir, "index.json")
+	indexFile, err := os.Open(indexFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open index.json for reading: %w", err)
+	}
+	defer indexFile.Close()
+
+	var idx v1.IndexManifest
+	err = json.NewDecoder(indexFile).Decode(&idx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifest from index.json: %w", err)
+	}
+
+	var scannables []trivyScannable
+	for _, m := range idx.Manifests {
+		scannables = append(scannables, imageInputScannable{
+			ArtifactName: m.Annotations["org.opencontainers.image.base.name"],
+			ociDir:       ociRootDir,
+			hash:         m.Digest.String(),
+		})
+	}
+
+	return scannables, nil
+}

--- a/pkg/scan/image_ref.go
+++ b/pkg/scan/image_ref.go
@@ -1,5 +1,33 @@
 package scan
 
+import "fmt"
+
+type ScannerType string
+
+const (
+	ImageScannerType  ScannerType = "image"
+	SBOMScannerType   ScannerType = "sbom"
+	RootFSScannerType ScannerType = "rootfs"
+)
+
+func (s *ScannerType) String() string {
+	return string(*s)
+}
+
+func (s *ScannerType) Set(v string) error {
+	switch v {
+	case string(ImageScannerType), string(SBOMScannerType), string(RootFSScannerType):
+		*s = ScannerType(v)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %v", []ScannerType{SBOMScannerType, RootFSScannerType, ImageScannerType})
+	}
+}
+
+func (s *ScannerType) Type() string {
+	return "ScannerType"
+}
+
 type trivyScannable interface {
 	TrivyCommand() []string
 }
@@ -32,4 +60,18 @@ func (r rootfsScannable) TrivyCommand() []string {
 
 func (r rootfsScannable) ArtifactNameOverride() string {
 	return r.ArtifactName
+}
+
+type imageInputScannable struct {
+	ArtifactName string
+	ociDir       string
+	hash         string
+}
+
+func (t imageInputScannable) TrivyCommand() []string {
+	return []string{"image", "--input", fmt.Sprintf("%s@%s", t.ociDir, t.hash)}
+}
+
+func (t imageInputScannable) ArtifactNameOverride() string {
+	return t.ArtifactName
 }

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -27,7 +27,7 @@ func TestNewLocalPackageScanner(t *testing.T) {
 		name        string
 		logger      types.Logger
 		packagePath string
-		sbom        bool
+		scannerType ScannerType
 		expected    *LocalPackageScanner
 		expectError bool
 	}{
@@ -35,11 +35,11 @@ func TestNewLocalPackageScanner(t *testing.T) {
 			name:        "valid inputs",
 			logger:      logger,
 			packagePath: packagePath,
-			sbom:        true,
+			scannerType: SBOMScannerType,
 			expected: &LocalPackageScanner{
 				logger:      logger,
 				packagePath: packagePath,
-				sbom:        true,
+				scannerType: SBOMScannerType,
 			},
 			expectError: false,
 		},
@@ -47,11 +47,11 @@ func TestNewLocalPackageScanner(t *testing.T) {
 			name:        "valid inputs for rootfs",
 			logger:      logger,
 			packagePath: packagePath,
-			sbom:        false,
+			scannerType: SBOMScannerType,
 			expected: &LocalPackageScanner{
 				logger:      logger,
 				packagePath: packagePath,
-				sbom:        false,
+				scannerType: SBOMScannerType,
 			},
 			expectError: false,
 		},
@@ -72,7 +72,7 @@ func TestNewLocalPackageScanner(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scanner, err := NewLocalPackageScanner(tt.logger, tt.packagePath, "", tt.sbom)
+			scanner, err := NewLocalPackageScanner(tt.logger, tt.packagePath, "", tt.scannerType)
 			checkError(t, err, tt.expectError)
 			if !tt.expectError {
 				if diff := cmp.Diff(tt.expected, scanner, cmp.AllowUnexported(LocalPackageScanner{})); diff != "" {
@@ -89,24 +89,28 @@ func TestScanImageE2E(t *testing.T) {
 	logger := log.NewLogger(ctx)
 
 	type testCase struct {
-		name string
-		sbom bool
+		name        string
+		scannerType ScannerType
 	}
 
 	testCases := []testCase{
 		{
-			name: "sbom",
-			sbom: true,
+			name:        "SBOM",
+			scannerType: SBOMScannerType,
 		},
 		{
-			name: "rootfs",
-			sbom: false,
+			name:        "RootFS",
+			scannerType: RootFSScannerType,
+		},
+		{
+			name:        "Image",
+			scannerType: ImageScannerType,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			lps, err := NewLocalPackageScanner(logger, zarfPackagePath, "", tt.sbom)
+			lps, err := NewLocalPackageScanner(logger, zarfPackagePath, "", tt.scannerType)
 			if err != nil {
 				t.Fatalf("Failed to create local package scanner: %v", err)
 			}
@@ -145,6 +149,7 @@ func TestScanImageE2E(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func checkError(t *testing.T, err error, expectError bool) {

--- a/pkg/scan/remote_scanner_test.go
+++ b/pkg/scan/remote_scanner_test.go
@@ -28,7 +28,7 @@ func TestNewScanResultReader(t *testing.T) {
 			wantErr:      false,
 		},
 	}
-	s := NewRemotePackageScanner(context.Background(), nil, "test", "test", "test", "test", nil, false)
+	s := NewRemotePackageScanner(context.Background(), nil, "test", "test", "test", "test", nil, RootFSScannerType)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := s.ScanResultReader(types.PackageScannerResult{JSONFilePath: tt.jsonFilePath})

--- a/pkg/scan/rootfs.go
+++ b/pkg/scan/rootfs.go
@@ -33,7 +33,7 @@ func extractTarToDir(outDir string, r io.Reader) error {
 	if errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(outDir, 0o700)
 		if err != nil {
-			return fmt.Errorf("failed to create output dir and it was not created beforehand: %w", err)
+			return fmt.Errorf("failed to create output dir and it did not exist beforehand: %w", err)
 		}
 	}
 
@@ -177,44 +177,33 @@ func extractAllImagesFromOCIDirectory(
 	return results, nil
 }
 
-type cleanupFunc func()
-
-func ExtractRootFsFromTarFilePath(tarFilePath string) ([]trivyScannable, cleanupFunc, error) {
+func ExtractRootFsFromTarFilePath(outputDir string, tarFilePath string) ([]trivyScannable, error) {
 	f, err := os.Open(tarFilePath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open tar: %w", err)
+		return nil, fmt.Errorf("failed to open tar: %w", err)
 	}
 
 	r, err := zstd.NewReader(f)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unzstd tar: %w", err)
+		return nil, fmt.Errorf("failed to unzstd tar: %w", err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "uds-local-scan-*")
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create tmp dir: %w", err)
-	}
-
-	pkgOutDir := path.Join(tmpDir, "oci")
+	pkgOutDir := path.Join(outputDir, "oci")
 	err = extractTarToDir(pkgOutDir, r)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	results, err := extractAllImagesFromOCIDirectory(
-		tmpDir,
+		outputDir,
 		path.Join(pkgOutDir, "images"),
 		path.Join(pkgOutDir, "images", "index.json"),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	cleanup := func() {
-		_ = os.RemoveAll(tmpDir)
-	}
-
-	return results, cleanup, nil
+	return results, nil
 }
 
 // replacePathChars replaces characters in a image name that will cause issues in filesystems.

--- a/pkg/scan/rootfs_test.go
+++ b/pkg/scan/rootfs_test.go
@@ -1,17 +1,23 @@
 package scan
 
 import (
+	"os"
 	"testing"
 )
 
 func TestExtractRootFsFromTarFilePath(t *testing.T) {
 	filePath := "testdata/zarf-package-mattermost-arm64-9.9.1-uds.0.tar.zst"
 
-	refs, cleanup, err := ExtractRootFsFromTarFilePath(filePath)
+	tmpDir, err := os.MkdirTemp("", "extract-rootfs-*")
+	if err != nil {
+		t.Fatalf("failed to create tmpdir: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	refs, err := ExtractRootFsFromTarFilePath(tmpDir, filePath)
 	if err != nil {
 		t.Fatalf("Failed to extract images from tar: %v", err)
 	}
-	defer cleanup()
 
 	if len(refs) != 1 {
 		t.Errorf("did not extract correct number of refs; want %d, got %d", 1, len(refs))

--- a/pkg/scan/sbom.go
+++ b/pkg/scan/sbom.go
@@ -20,12 +20,7 @@ const (
 	SbomFilename = "sboms.tar"
 )
 
-func extractSBOMImageRefsFromReader(r io.Reader) ([]trivyScannable, error) {
-	tmp, err := os.MkdirTemp("", "zarf-sbom-files-*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tmp dir: %w", err)
-	}
-
+func extractSBOMImageRefsFromReader(outputDir string, r io.Reader) ([]trivyScannable, error) {
 	var results []trivyScannable
 
 	sbomTarReader := tar.NewReader(r)
@@ -39,7 +34,7 @@ func extractSBOMImageRefsFromReader(r io.Reader) ([]trivyScannable, error) {
 		}
 
 		if strings.HasSuffix(header.Name, ".json") {
-			sbomImageRef, err := convertToCyclonedxFormat(header, sbomTarReader, tmp)
+			sbomImageRef, err := convertToCyclonedxFormat(header, sbomTarReader, outputDir)
 			if err != nil {
 				return nil, err
 			}
@@ -56,13 +51,13 @@ func extractSBOMImageRefsFromReader(r io.Reader) ([]trivyScannable, error) {
 // Returns:
 // - []sbomImageRef: references to images and their sboms.
 // - error: an error if the extraction fails.
-func ExtractSBOMsFromZarfTarFile(tarFilePath string) ([]trivyScannable, error) {
+func ExtractSBOMsFromZarfTarFile(outputDir string, tarFilePath string) ([]trivyScannable, error) {
 	sbomTar, err := extractSBOMTarFromZarfPackage(tarFilePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return extractSBOMImageRefsFromReader(bytes.NewReader(sbomTar))
+	return extractSBOMImageRefsFromReader(outputDir, bytes.NewReader(sbomTar))
 }
 
 func extractSBOMTarFromZarfPackage(tarFilePath string) ([]byte, error) {

--- a/pkg/scan/sbom_test.go
+++ b/pkg/scan/sbom_test.go
@@ -1,10 +1,20 @@
 package scan
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestExtractSBOMsFromTar(t *testing.T) {
 	filePath := "testdata/zarf-package-mattermost-arm64-9.9.1-uds.0.tar.zst"
-	refs, err := ExtractSBOMsFromZarfTarFile(filePath)
+
+	tmpDir, err := os.MkdirTemp("", "extract-sbom-*")
+	if err != nil {
+		t.Fatalf("failed to create tmpdir: %s", tmpDir)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	refs, err := ExtractSBOMsFromZarfTarFile(tmpDir, filePath)
 	if err != nil {
 		t.Fatalf("Failed to extract images from tar: %v", err)
 	}

--- a/pkg/scan/scan_factory.go
+++ b/pkg/scan/scan_factory.go
@@ -16,10 +16,10 @@ func (sf *ScannerFactoryImpl) CreateScanner(
 	logger types.Logger,
 	org, packageName, tag, packagePath, offlineDBPath string,
 	registryCredentials []types.RegistryCredentials,
-	sbom bool,
+	scannerType ScannerType,
 ) (types.PackageScanner, error) {
 	if packagePath != "" {
-		return NewLocalPackageScanner(logger, packagePath, offlineDBPath, sbom)
+		return NewLocalPackageScanner(logger, packagePath, offlineDBPath, scannerType)
 	}
 
 	if org == "" || packageName == "" || tag == "" {
@@ -34,6 +34,6 @@ func (sf *ScannerFactoryImpl) CreateScanner(
 		tag,
 		offlineDBPath,
 		registryCredentials,
-		sbom,
+		scannerType,
 	), nil
 }

--- a/pkg/scan/scan_factory_test.go
+++ b/pkg/scan/scan_factory_test.go
@@ -21,7 +21,7 @@ func TestCreateScanner_LocalPackage(t *testing.T) {
 	logger := log.NewLogger(context.Background())
 	packagePath := "/path/to/package"
 
-	scanner, err := sf.CreateScanner(context.Background(), logger, "", "", "", packagePath, "", nil, false)
+	scanner, err := sf.CreateScanner(context.Background(), logger, "", "", "", packagePath, "", nil, RootFSScannerType)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -36,7 +36,7 @@ func TestCreateScanner_RemotePackage(t *testing.T) {
 	packageName := "examplePackage"
 	tag := "latest"
 
-	scanner, err := sf.CreateScanner(context.Background(), nil, org, packageName, tag, "", "", nil, false)
+	scanner, err := sf.CreateScanner(context.Background(), nil, org, packageName, tag, "", "", nil, RootFSScannerType)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -48,7 +48,7 @@ func TestCreateScanner_RemotePackage(t *testing.T) {
 func TestCreateScanner_MissingParameters(t *testing.T) {
 	sf := &ScannerFactoryImpl{}
 
-	_, err := sf.CreateScanner(context.Background(), nil, "", "", "", "", "", nil, false)
+	_, err := sf.CreateScanner(context.Background(), nil, "", "", "", "", "", nil, RootFSScannerType)
 	expectedErr := "org, packageName, and tag are required for remote scanning"
 	if diff := cmp.Diff(expectedErr, err.Error()); diff != "" {
 		t.Errorf("unexpected error (-want +got):\n%s", diff)


### PR DESCRIPTION
This adds support for a different scanner type: image

This uses the `trivy image --input` scanner. This scanner will take in an oci directory and will scan based on a hash provided. We can read through the index.json and find a list of images to scan.


Given a package that has these images
```
> tar -Oxf ~/zpkg/zarf-package-sonarqube-amd64-9.9.5-uds.1.tar.zst images/index.json | jq -r '.manifests[].digest'
sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8
sha256:cbe461f2f26e573c5f4296c5f6c904011e3f1296dabf53e73b3f126d689c3463
sha256:98d2323dbda7a18bb1011ebddff7514b88f4ec30952c7f1d780485f968f48b67
```

it will run trivy commands like the following:
```
trivy image --input /tmp/dir@sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8
trivy image --input /tmp/dir@sha256:cbe461f2f26e573c5f4296c5f6c904011e3f1296dabf53e73b3f126d689c3463
trivy image --input /tmp/dir@sha256:98d2323dbda7a18bb1011ebddff7514b88f4ec30952c7f1d780485f968f48b67
```

Where trivy will read the layers for that specific image. The scan results are identical to the rootfs scanner. They run faster and require less disk space.

Comparison to rootfs scanner:
```
 > time ./bin/uds-security-hub -p ~/zpkg/zarf-package-sonarqube-amd64-9.9.5-uds.1.tar.zst -f rootfs.json --output-format json -s rootfs

________________________________________________________
Executed in    5.02 secs    fish           external
   usr time    5.65 secs  399.00 micros    5.65 secs
   sys time    1.14 secs  162.00 micros    1.14 secs

> time ./bin/uds-security-hub -p ~/zpkg/zarf-package-sonarqube-amd64-9.9.5-uds.1.tar.zst -f image.json --output-format json -s image

________________________________________________________
Executed in    1.36 secs    fish           external
   usr time    2.26 secs    0.00 micros    2.26 secs
   sys time    0.47 secs  574.00 micros    0.47 secs

> diff image.json rootfs.json
>
```