### PR TITLE
prevent scan duplicates for trivy results that have multiple result sets

### DIFF
--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -252,7 +253,7 @@ func getConfigFromFlags(cmd *cobra.Command) (*Config, error) {
 	logger := log.NewLogger(context.Background())
 	// this is for local sqlite db path and we would need to initialize the db and tables
 	if dbType == "sqlite" {
-		logger.Info("Using local SQLite database")
+		logger.Info("Using local SQLite database", zap.String("dbPath", dbPath))
 		dbConn, err = setupDBConnection(dbPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup database connection: %w", err)
@@ -295,8 +296,8 @@ func storeScanResults(ctx context.Context, scanner Scanner, manager ScanManager,
 			scanDTO.ArtifactName = result.ArtifactNameOverride
 		}
 
-		scanDTOs := external.MapScanResultToDTO(&scanDTO)
-		scans = append(scans, scanDTOs...)
+		mappedScanDTO := external.MapScanResultToDTO(&scanDTO)
+		scans = append(scans, mappedScanDTO)
 	}
 
 	packageDTO := external.PackageDTO{

--- a/internal/external/scan_result.go
+++ b/internal/external/scan_result.go
@@ -55,7 +55,10 @@ func MapScanResultToDTO(result *ScanResult) ScanDTO {
 		ArtifactType:  result.ArtifactType,
 		CreatedAt:     result.CreatedAt,
 	}
-	dto.Metadata, _ = json.Marshal(result.Metadata) //nolint:errcheck
+	metadata, err := json.Marshal(result.Metadata)
+	if err == nil {
+		dto.Metadata = metadata
+	}
 
 	// there can be multiple results per scan, we want to take all of the vulns
 	// and map them to a single ScanDTO

--- a/internal/external/scan_result.go
+++ b/internal/external/scan_result.go
@@ -55,7 +55,7 @@ func MapScanResultToDTO(result *ScanResult) ScanDTO {
 		ArtifactType:  result.ArtifactType,
 		CreatedAt:     result.CreatedAt,
 	}
-	dto.Metadata, _ = json.Marshal(result.Metadata) //nolint:errcheckjson
+	dto.Metadata, _ = json.Marshal(result.Metadata) //nolint:errcheck
 
 	// there can be multiple results per scan, we want to take all of the vulns
 	// and map them to a single ScanDTO

--- a/internal/external/scan_result.go
+++ b/internal/external/scan_result.go
@@ -7,7 +7,6 @@ import (
 	"github.com/defenseunicorns/uds-security-hub/internal/data/model"
 )
 
-// go:bui
 // ScanResult is a struct that represents the scan result.
 type ScanResult struct {
 	Metadata     model.Metadata `json:"Metadata"`

--- a/internal/external/scan_result.go
+++ b/internal/external/scan_result.go
@@ -48,26 +48,33 @@ type PackageDTO struct {
 }
 
 // MapScanResultToDTO maps the ScanResult to a slice of ScanDTO.
-func MapScanResultToDTO(result *ScanResult) []ScanDTO {
-	var dtos []ScanDTO
-	for _, res := range result.Results {
-		metadataJSON, err := json.Marshal(result.Metadata)
-		if err != nil {
-			// Handle error appropriately
-			continue
-		}
-		dto := ScanDTO{
-			ID:              result.ID,
-			SchemaVersion:   result.SchemaVersion,
-			CreatedAt:       result.CreatedAt,
-			ArtifactName:    result.ArtifactName,
-			ArtifactType:    result.ArtifactType,
-			Metadata:        json.RawMessage(metadataJSON),
-			Vulnerabilities: res.Vulnerabilities,
-		}
-		dtos = append(dtos, dto)
+func MapScanResultToDTO(result *ScanResult) ScanDTO {
+	dto := ScanDTO{
+		ID:            result.ID,
+		SchemaVersion: result.SchemaVersion,
+		ArtifactName:  result.ArtifactName,
+		ArtifactType:  result.ArtifactType,
+		CreatedAt:     result.CreatedAt,
 	}
-	return dtos
+	dto.Metadata, _ = json.Marshal(result.Metadata) //nolint:errcheckjson
+
+	// there can be multiple results per scan, we want to take all of the vulns
+	// and map them to a single ScanDTO
+	for _, res := range result.Results {
+		for i := range res.Vulnerabilities {
+			vuln := res.Vulnerabilities[i]
+
+			// copy these fields over, they are not in the vulnerability
+			// and exist in the result
+			vuln.Target = res.Target
+			vuln.Type = res.Type
+			vuln.Class = res.Class
+
+			dto.Vulnerabilities = append(dto.Vulnerabilities, vuln)
+		}
+	}
+
+	return dto
 }
 
 // MapPackageToDTO maps the Package to a PackageDTO.

--- a/internal/external/scan_result_test.go
+++ b/internal/external/scan_result_test.go
@@ -74,15 +74,12 @@ func TestMapScanResultToDTO(t *testing.T) {
 		},
 		DiffIDs: []string{"test-diff-id"},
 	}
+
 	metadataJSON, err := json.Marshal(metadata)
 	if err != nil {
 		t.Fatalf("Failed to marshal metadata: %s", err)
 	}
-	vulnerabilities := []model.Vulnerability{
-		{
-			PkgName: "test-pkg-name",
-		},
-	}
+
 	createdAt := time.Now()
 
 	scanResult := &ScanResult{
@@ -97,25 +94,67 @@ func TestMapScanResultToDTO(t *testing.T) {
 			Vulnerabilities []model.Vulnerability `json:"Vulnerabilities"`
 		}{
 			{
-				Target:          "test-target",
-				Class:           "test-class",
-				Type:            "test-type",
-				Vulnerabilities: vulnerabilities,
+				Target: "/some/long/filename",
+				Class:  "os-pkg",
+				Type:   "chainguard",
+				Vulnerabilities: []model.Vulnerability{
+					{
+						PkgName: "os-pkg-result-1",
+					},
+					{
+						PkgName: "os-pkg-result-2",
+					},
+				},
 			},
+			{
+				Target: "NodeJS",
+				Class:  "lang-pkgs",
+				Type:   "node-pkg",
+				Vulnerabilities: []model.Vulnerability{
+					{
+						PkgName: "lang-pkg-result-1",
+					},
+					{
+						PkgName: "lang-pkg-result-2",
+					},
+				}},
 		},
 		SchemaVersion: 1,
 		ID:            123,
 	}
 
-	expectedDTOs := []ScanDTO{
-		{
-			ID:              123,
-			SchemaVersion:   1,
-			CreatedAt:       createdAt,
-			ArtifactName:    "test-artifact",
-			ArtifactType:    "test-type",
-			Metadata:        json.RawMessage(metadataJSON),
-			Vulnerabilities: vulnerabilities,
+	expectedDTO := ScanDTO{
+		ID:            123,
+		SchemaVersion: 1,
+		CreatedAt:     createdAt,
+		ArtifactName:  "test-artifact",
+		ArtifactType:  "test-type",
+		Metadata:      json.RawMessage(metadataJSON),
+		Vulnerabilities: []model.Vulnerability{
+			{
+				Target:  "/some/long/filename",
+				Class:   "os-pkg",
+				Type:    "chainguard",
+				PkgName: "os-pkg-result-1",
+			},
+			{
+				Target:  "/some/long/filename",
+				Class:   "os-pkg",
+				Type:    "chainguard",
+				PkgName: "os-pkg-result-2",
+			},
+			{
+				Target:  "NodeJS",
+				Class:   "lang-pkgs",
+				Type:    "node-pkg",
+				PkgName: "lang-pkg-result-1",
+			},
+			{
+				Target:  "NodeJS",
+				Class:   "lang-pkgs",
+				Type:    "node-pkg",
+				PkgName: "lang-pkg-result-2",
+			},
 		},
 	}
 
@@ -123,7 +162,7 @@ func TestMapScanResultToDTO(t *testing.T) {
 	actualDTOs := MapScanResultToDTO(scanResult)
 
 	// Compare the expected and actual DTOs
-	if diff := cmp.Diff(expectedDTOs, actualDTOs, cmpopts.IgnoreFields(model.Scan{}, "CreatedAt", "UpdatedAt")); diff != "" {
+	if diff := cmp.Diff(expectedDTO, actualDTOs); diff != "" {
 		t.Errorf("MapScanResultToDTO() mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
I found that trivy results can include multiple result sets, and we were mapping those each to a ScanDTO

for context, this is a trivy result: https://github.com/defenseunicorns/uds-security-hub/blob/e31dc424435183e4cbbd448c80914327f1b6b5fa/internal/external/scan_result.go#L17

and here is where we were creating those ScanDTO entities: https://github.com/defenseunicorns/uds-security-hub/blob/e31dc424435183e4cbbd448c80914327f1b6b5fa/internal/external/scan_result.go#L53-L69

ghcr.io/defenseunicorns/pepr/controller:v0.34.1 was one of those that had these multiple result sets, which is why it showed up as 2 scans


this should resolve #201 



