### PR TITLE
 Ensure Temporary Files are Properly Cleaned Up

### DIFF
--- a/pkg/scan/sbom.go
+++ b/pkg/scan/sbom.go
@@ -25,6 +25,7 @@ func extractSBOMImageRefsFromReader(r io.Reader) ([]trivyScannable, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tmp dir: %w", err)
 	}
+	defer os.RemoveAll(tmp) // Ensure the temporary directory is cleaned up
 
 	var results []trivyScannable
 


### PR DESCRIPTION
This PR ensures that temporary files created during scanning are properly cleaned/
### Related Issue
Fixes #177