### PR TITLE
feat: Embed Git commit SHA and latest Git tag into Go binary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,5 +40,8 @@ jobs:
     - name: Build
       run: make build
 
+    - name: Verify Version
+      run: make verify-version
+
     - name: Clean
       run: make clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - "-X main.Version={{.Version}} -X main.Commit={{.Commit}}"
 
 archives:
   - format: binary

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,14 @@ test-integration:
 	fi
 	integration=true go test -timeout 160s ./... -v -coverprofile=coverage.out
 
-.PHONY: all build test lint run clean e2e table-init
+verify-version:
+	@for binary in uds-security-hub store; do \
+		VERSION_OUTPUT=$$(./bin/$$binary --version); \
+		echo "Version output for $$binary: $$VERSION_OUTPUT"; \
+		if [[ $$VERSION_OUTPUT != *\"version\"* || $$VERSION_OUTPUT != *\"commit\"* ]]; then \
+			echo "Version information not embedded correctly in $$binary"; \
+			exit 1; \
+		fi; \
+	done
+
+.PHONY: all build test lint run clean e2e table-init verify-version

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,20 @@ SHELL := /bin/bash
 # Default target
 all: build
 
+# Get the current Git commit SHA and the latest Git tag
+GIT_COMMIT := $(shell git rev-parse HEAD)
+GIT_TAG := $(shell git describe --tags --abbrev=0)
+
 # Build the project
 build:
-	go build -o bin/uds-security-hub main.go
-	go build -o bin/table-init ./cmd/table-init/main.go
-	go build -o bin/store ./cmd/store/main.go
+	go build -ldflags "-X 'github.com/defenseunicorns/uds-security-hub/pkg/version.CommitSHA=$(GIT_COMMIT)' -X 'github.com/defenseunicorns/uds-security-hub/pkg/version.Version=$(GIT_TAG)'" -o bin/uds-security-hub main.go
+	go build -ldflags "-X 'github.com/defenseunicorns/uds-security-hub/pkg/version.CommitSHA=$(GIT_COMMIT)' -X 'github.com/defenseunicorns/uds-security-hub/pkg/version.Version=$(GIT_TAG)'" -o bin/table-init ./cmd/table-init/main.go
+	go build -ldflags "-X 'github.com/defenseunicorns/uds-security-hub/pkg/version.CommitSHA=$(GIT_COMMIT)' -X 'github.com/defenseunicorns/uds-security-hub/pkg/version.Version=$(GIT_TAG)'" -o bin/store ./cmd/store/main.go
+	go build -ldflags "-X 'github.com/defenseunicorns/uds-security-hub/pkg/version.CommitSHA=$(GIT_COMMIT)' -X 'github.com/defenseunicorns/uds-security-hub/pkg/version.Version=$(GIT_TAG)'" -o bin/scan ./cmd/scan.go
 
 # Lint the code
 lint:
-	 golangci-lint run ./...
+	golangci-lint run ./...
 
 # Clean the build
 clean:

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -155,15 +155,3 @@ func runScanner(cmd *cobra.Command, _ []string) error {
 
 	return nil
 }
-
-func main() {
-	rootCmd := newRootCmd()
-
-	rootCmd.Version = fmt.Sprintf("%s (commit %s)", version.Version, version.CommitSHA)
-	rootCmd.SetVersionTemplate("{{.Version}}\n")
-
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error executing command:", err)
-		os.Exit(1)
-	}
-}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/defenseunicorns/uds-security-hub/internal/log"
 	"github.com/defenseunicorns/uds-security-hub/pkg/scan"
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
+	"github.com/defenseunicorns/uds-security-hub/pkg/version"
 )
 
 // errFlagRetrieval is the error message for when a flag cannot be retrieved.
@@ -26,6 +27,8 @@ var scannerType scan.ScannerType = scan.RootFSScannerType
 // Execute is the main entry point for the scanner.
 func Execute(args []string) {
 	rootCmd := newRootCmd()
+	rootCmd.Version = fmt.Sprintf(`{"version": "%s", "commit": "%s"}`, version.Version, version.CommitSHA)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.SetArgs(args) // Set the arguments
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -151,4 +154,16 @@ func runScanner(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func main() {
+	rootCmd := newRootCmd()
+
+	rootCmd.Version = fmt.Sprintf("%s (commit %s)", version.Version, version.CommitSHA)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error executing command:", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/defenseunicorns/uds-security-hub/internal/sql"
 	"github.com/defenseunicorns/uds-security-hub/pkg/scan"
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
+	"github.com/defenseunicorns/uds-security-hub/pkg/version"
 )
 
 // Scanner is the interface for the scanner.
@@ -327,7 +328,9 @@ func main() {
 // Execute executes the store command.
 func Execute(args []string) {
 	rootCmd := newStoreCmd()
-	rootCmd.SetArgs(args) // Set the arguments
+	rootCmd.Version = fmt.Sprintf(`{"version": "%s", "commit": "%s"}`, version.Version, version.CommitSHA)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	rootCmd.SetArgs(args)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error executing command:", err)
 		os.Exit(1)

--- a/images/uds-security-hub-store/melange.yaml
+++ b/images/uds-security-hub-store/melange.yaml
@@ -28,7 +28,10 @@ pipeline:
     runs: >
       set -x
 
-      CGO_ENABLED=1 go build -o "${{targets.destdir}}/usr/sbin/store" ./cmd/store
+      VERSION=$(git describe --tags --abbrev=0)
+      COMMIT=$(git rev-parse HEAD)
+      CGO_ENABLED=1 go build -ldflags "-X main.Version=${VERSION} -X main.Commit=${COMMIT}" -o "${{targets.destdir}}/usr/sbin/store" ./cmd/store
+
   - name: Create dummy Docker config for Google Cloud
     runs: >
       set -x

--- a/images/uds-security-hub/melange.yaml
+++ b/images/uds-security-hub/melange.yaml
@@ -28,7 +28,10 @@ pipeline:
     runs: >
       set -x
 
-      CGO_ENABLED=1 go build -o "${{targets.destdir}}/usr/sbin/uds-security-hub" main.go
+      VERSION=$(git describe --tags --abbrev=0)
+      COMMIT=$(git rev-parse HEAD)
+      CGO_ENABLED=1 go build -ldflags "-X main.Version=${VERSION} -X main.Commit=${COMMIT}" -o "${{targets.destdir}}/usr/sbin/uds-security-hub" main.go
+
   - name: Create dummy Docker config for Google Cloud
     runs: >
       set -x

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	CommitSHA string
+	Version   string
+)


### PR DESCRIPTION
This commit addresses issue #214 by embedding the current Git commit SHA and the latest Git tag into the Go binary. This enhancement allows for better tracking and debugging of the code version at runtime.

Changes include:
- **Melange YAML Files**: Updated `images/uds-security-hub/melange.yaml` and `images/uds-security-hub-store/melange.yaml` to include `VERSION` and `COMMIT` variables, and modified the `go build` command to use `-ldflags` for embedding these variables.
- **Makefile**: Added `GIT_COMMIT` and `GIT_TAG` variables to capture the current Git commit SHA and the latest Git tag. Updated the `go build` commands to use `-ldflags` for embedding these variables.
- **Go Source Files**:
  - Updated `cmd/scan.go` and `cmd/store/main.go` to include the version and commit information in the command output.
  - Added `version` package to hold the version and commit variables.

These changes ensure the version information is embedded at build time and can be accessed via the command-line interface's `--version` flag.

``` shell
➜  uds-security-hub git:(naveen/version-info) ./bin/uds-security-hub -v
{"version": "v0.1.0", "commit": "f3635690974fe8dd319b17c7fee2f4632a77c389"}
➜  uds-security-hub git:(naveen/version-info) ./bin/store --version
{"version": "v0.1.0", "commit": "f3635690974fe8dd319b17c7fee2f4632a77c389"}
```

Closes #214