### PR TITLE
Fix paths in leapfrog_names.txt to include `/uds`

### DIFF
--- a/scripts/leapfrog_names.txt
+++ b/scripts/leapfrog_names.txt
@@ -1,6 +1,7 @@
-packages/leapfrogai/whisper
-packages/leapfrogai/rag
-packages/leapfrogai/vllm
-packages/leapfrogai/leapfrogai-api
-packages/leapfrogai/text-embeddings
-packages/leapfrogai/leapfrogai-ui
+packages/uds/leapfrogai/whisper
+packages/uds/leapfrogai/vllm
+packages/uds/leapfrogai/leapfrogai-api
+packages/uds/leapfrogai/llama-cpp-python
+packages/uds/leapfrogai/text-embeddings
+packages/uds/leapfrogai/leapfrogai-ui
+packages/uds/leapfrogai/supabase


### PR DESCRIPTION
LeapfrogAI v0.12.0 included a breaking change which updated the directory structure to comply with the Made for UDS standard. Reference: https://github.com/defenseunicorns/leapfrogai/pull/933

This PR updates the paths in leapfrogai_names.txt accordingly. It also removes the `rag` package, which is no longer relevant, and adds the `supabase` package to the list.