### PR TITLE
chore: pin toolchain version, use `go.mod` version in `actions/setup-go`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.23' 
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make build

--- a/.github/workflows/goreleaser-test.yml
+++ b/.github/workflows/goreleaser-test.yml
@@ -43,8 +43,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.22.4'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Install syft
       uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0

--- a/.github/workflows/leapfrog-scan.yaml
+++ b/.github/workflows/leapfrog-scan.yaml
@@ -2,8 +2,8 @@ name: Leapfrog Scan
 
 on:
   schedule:
-    - cron: '0 23 * * *'  
-  workflow_dispatch:      
+    - cron: '0 23 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read  
+      contents: read
 
 
     steps:
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2
         with:
-          go-version: '1.22.4'  
+          go-version-file: 'go.mod'
 
       - name: Install Trivy
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/slsa.yaml
+++ b/.github/workflows/slsa.yaml
@@ -52,8 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.22.4
-          check-latest: true
+          go-version-file: 'go.mod'
       - name: Install syft
         uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0
         with:
@@ -63,7 +62,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: latest
-          args: release 
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate subject

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.23' 
+        go-version-file: 'go.mod'
 
     - name: Install Trivy
       run: |
@@ -57,4 +57,4 @@ jobs:
         sudo apt-get install trivy -y
 
     - name: Unit Tests
-      run: make test-unit   
+      run: make test-unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.23' 
+        go-version-file: 'go.mod'
 
     - name: Install Trivy
       run: |

--- a/.github/workflows/uds-scan.yaml
+++ b/.github/workflows/uds-scan.yaml
@@ -2,8 +2,8 @@ name: UDS Scan
 
 on:
   schedule:
-    - cron: '0 2 * * *'   
-  workflow_dispatch:      
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v2
         with:
-          go-version: '1.23'  
+          go-version-file: 'go.mod'
 
       - name: Install Trivy
         run: |
@@ -70,5 +70,5 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           chmod +x scripts/scan.sh
-          ./scripts/scan.sh -f names.txt -v 2 
+          ./scripts/scan.sh -f names.txt -v 2
           ./scripts/scan.sh -f leapfrog_names.txt -v 1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/defenseunicorns/uds-security-hub
 
 go 1.23
+toolchain go1.23.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.12.0


### PR DESCRIPTION
This fixes errors like the following for when `local` go version does not match the one specified in `go.mod`:

```
$ go version
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```

See https://github.com/golang/go/issues/62278#issuecomment-1693538776 for details.

It appears that as of `1.22` the `go` directive is still used to indicate the module's minimum required version of go, but is _also used_ as the default value for the `toolchain` directive. `toolchain` MUST point to a specific release version (i.e. `go1.23.0`).

In the future, we should _only_ bump the `toolchain` version and leave the minimum version in the `go` directive alone unless it is _required_ to build the software.