### PR TITLE
chore(lint/ci): simplify configuration per gocritic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - forbidigo
     - gci
     - gochecknoinits
@@ -102,17 +101,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
-      - appendAssign
-      - badCond
-      - caseOrder
-      - codegenComment
       - commentedOutCode
-      - deprecatedComment
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagName
       - nilValReturn
       - weakCond
       - octalLiteral
@@ -125,22 +114,13 @@ linters-settings:
 
       # Style
       - boolExprSimplify
-      - captLocal
-      - commentFormatting
       - commentedOutImport
-      - defaultCaseOrder
       - docStub
-      - elseif
       - emptyFallthrough
       - hexLiteral
-      - ifElseChain
       - methodExprCall
-      - singleCaseSwitch
       - typeAssertChain
-      - typeSwitchVar
-      - underef
       - unlabelStmt
-      - unlambda
 
       # Opinionated
       - builtinShadow


### PR DESCRIPTION
`gocritic` was producing the below [in CI](https://github.com/defenseunicorns/uds-security-hub/actions/runs/10948463167/job/30399536294) - [this change addresses that](https://github.com/defenseunicorns/uds-security-hub/actions/runs/10949618214/job/30403248354?pr=270).

```
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  level=warning msg="[linters_context] gocritic: no need to enable check \"appendAssign\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"badCond\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"caseOrder\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"codegenComment\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"deprecatedComment\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"dupBranchBody\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"dupCase\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"dupSubExpr\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"exitAfterDefer\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"flagName\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"captLocal\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"commentFormatting\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"defaultCaseOrder\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"elseif\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"ifElseChain\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"singleCaseSwitch\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"typeSwitchVar\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"underef\": it's already enabled"
  level=warning msg="[linters_context] gocritic: no need to enable check \"unlambda\": it's already enabled"
```