### PR TITLE
fix leapfrog scan workflow

### DIFF
--- a/.github/workflows/leapfrog-scan.yaml
+++ b/.github/workflows/leapfrog-scan.yaml
@@ -2,7 +2,8 @@ name: Leapfrog Scan
 
 on:
   schedule:
-    - cron: '0 23 * * *'
+    # Scheduled to run everyday at 2:00 AM UTC/ 8:00 PM MT
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/leapfrog-scan.yaml
+++ b/.github/workflows/leapfrog-scan.yaml
@@ -65,6 +65,7 @@ jobs:
           DB_USER: ${{ secrets.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           INSTANCE_CONNECTION_NAME: ${{ secrets.INSTANCE_CONNECTION_NAME }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           chmod +x scripts/scan.sh
           ./scripts/scan.sh -f leapfrog_names.txt -v 1


### PR DESCRIPTION
scans failing because `SLACK_WEBHOOK_URL` is not set
- added and set `SLACK_WEB_HOOK` env
- added comment to cron job for clarity and also changed cron job to align with `UDS Scan` (unless there is a specific reason why our scans are all run at different times)