### PR TITLE
refactor pkg/scan/* files

### DIFF
--- a/pkg/scan/e2e_test.go
+++ b/pkg/scan/e2e_test.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/defenseunicorns/uds-security-hub/internal/docker"
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestE2EScanFunctionality(t *testing.T) {

--- a/pkg/scan/e2e_test.go
+++ b/pkg/scan/e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/defenseunicorns/uds-security-hub/internal/docker"
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestE2EScanFunctionality(t *testing.T) {
@@ -31,9 +32,7 @@ func TestE2EScanFunctionality(t *testing.T) {
 			ctx := context.Background()
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 			ghcrCreds := os.Getenv("GHCR_CREDS")
-			if ghcrCreds == "" {
-				t.Fatalf("GHCR_CREDS must be set")
-			}
+			require.NotEmpty(t, ghcrCreds, "GHCR_CREDS must be set")
 			registryCreds := docker.ParseCredentials([]string{ghcrCreds})
 			// Define the test inputs
 
@@ -44,38 +43,28 @@ func TestE2EScanFunctionality(t *testing.T) {
 			scanner := NewRemotePackageScanner(ctx, logger, org, packageName, tag, "", registryCreds, tt.scannerType)
 			// Perform the scan
 			scan, err := scanner.Scan(ctx)
-			if err != nil {
-				t.Fatalf("Error scanning package: %v", err)
-			}
+			require.NoError(t, err, "error scanning package")
 
 			var allResults []types.ScanResultReader
 
 			for _, v := range scan.Results {
 				r, err := scanner.ScanResultReader(v)
-				if err != nil {
-					t.Fatalf("Error reading scan result: %v", err)
-				}
+				require.NoError(t, err, "error reading scan result")
 
 				allResults = append(allResults, r)
 			}
 
 			// Process the results
 			var buf bytes.Buffer
-			if err := WriteToCSV(&buf, allResults); err != nil {
-				t.Fatalf("failed to WriteToCSV: %v", err)
-			}
+			require.NoError(t, WriteToCSV(&buf, allResults), "failed to WriteToCSV")
 			combinedCSV := buf.String()
 
 			// Verify the combined CSV output
-			if len(combinedCSV) == 0 {
-				t.Fatalf("Combined CSV output is empty")
-			}
+			require.NotEmpty(t, combinedCSV, "combined csv output is empty")
 
 			// make sure the header only exists in the first line
 			lines := strings.Split(combinedCSV, "\n")
-			if slices.Contains(lines[1:], lines[0]) {
-				t.Error("the header line appears more than once")
-			}
+			require.False(t, slices.Contains(lines[1:], lines[0]), "the header line appears more than once")
 		})
 	}
 }

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -195,7 +195,7 @@ func TestExtractFilesFromTar(t *testing.T) {
 			results, err := extractFilesFromTar(tt.reader, tt.filenames...)
 			checkError(t, err, tt.expectErr)
 			diff := cmp.Diff(tt.wantResult, results)
-			require.Empty(t, diff, "results mismatch (-want +got):\n%s", diff)
+			require.Empty(t, diff)
 		})
 	}
 }

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -156,8 +156,8 @@ func TestExtractFilesFromTar(t *testing.T) {
 
 	_, err := tw.Write(data)
 	require.NoError(t, err, "error writing data to tar")
-
-	require.NoError(t, tw.Close(), "failed to close writer")
+	err = tw.Close()
+	require.NoError(t, err, "failed to close writer")
 
 	tests := []struct {
 		name       string

--- a/pkg/scan/local_scan_test.go
+++ b/pkg/scan/local_scan_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
 )
@@ -70,9 +71,8 @@ func TestNewLocalPackageScanner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner, err := NewLocalPackageScanner(tt.logger, tt.packagePath, "", tt.scannerType)
 			checkError(t, err, tt.expectError)
-			if diff := cmp.Diff(tt.expected, scanner, cmp.AllowUnexported(LocalPackageScanner{}), cmpopts.IgnoreUnexported(slog.Logger{})); diff != "" {
-				t.Errorf("scanner mismatch (-expected +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.expected, scanner, cmp.AllowUnexported(LocalPackageScanner{}), cmpopts.IgnoreUnexported(slog.Logger{}))
+			require.Empty(t, diff, "scanner mismatch (-expected +got):\n%s", diff)
 		})
 	}
 }
@@ -101,42 +101,23 @@ func TestScanImageE2E(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			lps, err := NewLocalPackageScanner(logger, zarfPackagePath, "", tt.scannerType)
-			if err != nil {
-				t.Fatalf("Failed to create local package scanner: %v", err)
-			}
+			require.NoError(t, err, "failed to create local package scanner")
 			result, err := lps.Scan(ctx)
-			if err != nil {
-				t.Fatalf("Failed to scan image: %v", err)
-			}
+			require.NoError(t, err, "failed to scan image")
 			reader, err := lps.ScanResultReader(result.Results[0])
-			if err != nil {
-				t.Fatalf("Failed to get scan result reader: %v", err)
-			}
+			require.NoError(t, err, "failed to get scan result reader")
 			artifactName := reader.GetArtifactName()
-			if artifactName == "" {
-				t.Fatalf("Expected artifact name to be non-empty, got %s", artifactName)
-			}
+			require.NotEmpty(t, artifactName, "expected artifact name to be non-empty, got empty")
 			vulnerabilities := reader.GetVulnerabilities()
-			if len(vulnerabilities) == 0 {
-				t.Fatalf("Expected non-empty vulnerabilities, got empty")
-			}
+			require.NotEmpty(t, vulnerabilities, "expected vulnerabilities to be non-empty, got empty")
 			var buf bytes.Buffer
-			if err := WriteToJSON(&buf, []types.ScanResultReader{reader}); err != nil {
-				t.Fatalf("Error writing JSON: %v", err)
-			}
+			require.NoError(t, WriteToJSON(&buf, []types.ScanResultReader{reader}), "error writing json")
 			jsonOutput := buf.String()
-			if jsonOutput == "" {
-				t.Fatalf("Expected non-empty JSON, got empty")
-			}
+			require.NotEmpty(t, jsonOutput, "expected JSON to be non-empty, got empty")
 			buf.Reset() // Reset buffer for CSV writing
-
-			if err := WriteToCSV(&buf, []types.ScanResultReader{reader}); err != nil {
-				t.Fatalf("Error writing CSV: %v", err)
-			}
+			require.NoError(t, WriteToCSV(&buf, []types.ScanResultReader{reader}), "error writing csv")
 			csvOutput := buf.String()
-			if csvOutput == "" {
-				t.Fatalf("Expected non-empty CSV, got empty")
-			}
+			require.NotEmpty(t, csvOutput, "expected csv to be non-empty, got empty")
 		})
 	}
 }
@@ -145,11 +126,11 @@ func checkError(t *testing.T, err error, expectError bool) {
 	t.Helper()
 	if expectError {
 		if err == nil {
-			t.Fatalf("expected error, got nil")
+			require.Error(t, err, "expected an error, but got none")
 		}
 	} else {
 		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
+			require.NoError(t, err, "expected no error, but got one")
 		}
 	}
 }
@@ -163,23 +144,20 @@ func TestLocalPackageScanner_Scan_LPSEmptyPackagePath(t *testing.T) {
 	}
 
 	_, err := lps.Scan(context.Background())
-	if err == nil || err.Error() != "packagePath cannot be empty" {
-		t.Fatalf("Expected error for empty packagePath, got: %v", err)
-	}
+	require.Error(t, err, "expected error for empty packagePath, got :%v", err)
+	require.ErrorContains(t, err, "packagePath cannot be empty", "unexpected error message")
 }
 
 func TestExtractFilesFromTar(t *testing.T) {
 	data := []byte("mock data")
 	buf := bytes.NewBuffer(nil)
 	tw := tar.NewWriter(buf)
-	if err := tw.WriteHeader(&tar.Header{Name: "testfile.txt", Size: int64(len(data))}); err != nil {
-		t.Fatalf("Error writing tar header: %v", err)
-	}
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "testfile.txt", Size: int64(len(data))}), "error writing tar header")
 
-	if _, err := tw.Write(data); err != nil {
-		t.Fatalf("Error writing data to tar: %v", err)
-	}
-	tw.Close()
+	_, err := tw.Write(data)
+	require.NoError(t, err, "error writing data to tar")
+
+	require.NoError(t, tw.Close(), "failed to close writer")
 
 	tests := []struct {
 		name       string
@@ -216,9 +194,8 @@ func TestExtractFilesFromTar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			results, err := extractFilesFromTar(tt.reader, tt.filenames...)
 			checkError(t, err, tt.expectErr)
-			if diff := cmp.Diff(tt.wantResult, results); diff != "" {
-				t.Errorf("results mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.wantResult, results)
+			require.Empty(t, diff, "results mismatch (-want +got):\n%s", diff)
 		})
 	}
 }

--- a/pkg/scan/rootfs_test.go
+++ b/pkg/scan/rootfs_test.go
@@ -2,8 +2,9 @@ package scan
 
 import (
 	"os"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSanitizeArchivePath(t *testing.T) {
@@ -20,8 +21,10 @@ func TestSanitizeArchivePath(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.filename, func(t *testing.T) {
 			_, err := sanitizeArchivePath(tc.dir, tc.filename)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("got error %v, want error %v", err != nil, tc.wantErr)
+			if tc.wantErr {
+				require.Error(t, err, "expected error but got none")
+			} else {
+				require.NoError(t, err, "got an unexpected error")
 			}
 		})
 	}
@@ -29,67 +32,51 @@ func TestSanitizeArchivePath(t *testing.T) {
 
 func TestUnmarshalJSONFromFilename(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "test.yaml")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	require.NoError(t, err, "failed to create temp file: %v", err)
 	defer os.Remove(tmpFile.Name())
 
 	validYAML := "key: value"
-	if _, err := tmpFile.WriteString(validYAML); err != nil {
-		t.Fatalf("failed to write to temp file: %v", err)
-	}
-	tmpFile.Close()
+	_, err = tmpFile.WriteString(validYAML)
+	require.NoError(t, err, "failed to write to temp file")
+
+	require.NoError(t, tmpFile.Close(), "failed to close temp file")
 
 	var output map[string]string
 	err = unmarshalJSONFromFilename(tmpFile.Name(), &output)
-	if err != nil || output["key"] != "value" {
-		t.Errorf("failed to unmarshal valid YAML, got: %v", err)
-	}
+	require.NoError(t, err, "failed to unmarshal valid YAML")
+	require.Equal(t, "value", output["key"], "unexpected value for 'key'")
 
 	invalidFile := "nonexistent.yaml"
 	err = unmarshalJSONFromFilename(invalidFile, &output)
-	if err == nil {
-		t.Errorf("expected error for nonexistent file, got none")
-	}
+	require.Error(t, err, "expected error for nonexistent file, but got none")
 }
 
 func TestUnmarshalJSONFromFilename_DecodeError(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "invalid*.yaml")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
+	require.NoError(t, err, "failed to create temp file: %v", err)
 	defer os.Remove(tmpFile.Name())
 
 	_, err = tmpFile.WriteString("invalid_yaml: [unterminated")
-	if err != nil {
-		t.Fatalf("failed to write to temp file: %v", err)
-	}
+	require.NoError(t, err, "failed to write to temp file: %v", err)
 	tmpFile.Close()
 
 	var output map[string]interface{}
 	err = unmarshalJSONFromFilename(tmpFile.Name(), &output)
-	if err == nil || !strings.Contains(err.Error(), "failed to decode") {
-		t.Errorf("expected decode error, got: %v", err)
-	}
+	require.Error(t, err, "expected decode error, but got none")
+	require.ErrorContains(t, err, "failed to decode")
 }
 
 func TestExtractRootFsFromTarFilePath(t *testing.T) {
 	filePath := "testdata/zarf-package-mattermost-arm64-9.9.1-uds.0.tar.zst"
 
 	tmpDir, err := os.MkdirTemp("", "extract-rootfs-*")
-	if err != nil {
-		t.Fatalf("failed to create tmpdir: %s", err)
-	}
+	require.NoError(t, err, "failed to create tmpdir: %s", err)
 	defer os.RemoveAll(tmpDir)
 
 	refs, err := ExtractRootFsFromTarFilePath(tmpDir, filePath)
-	if err != nil {
-		t.Fatalf("Failed to extract images from tar: %v", err)
-	}
+	require.NoError(t, err, "failed to extract images from tar: %v", err)
 
-	if len(refs) != 1 {
-		t.Errorf("did not extract correct number of refs; want %d, got %d", 1, len(refs))
-	}
+	require.Len(t, refs, 1, "did not extract number of refs; want %d, got %d", 1, len(refs))
 }
 
 func TestReplacePathChars(t *testing.T) {
@@ -110,9 +97,7 @@ func TestReplacePathChars(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.input, func(t *testing.T) {
 			result := replacePathChars(testCase.input)
-			if result != testCase.expected {
-				t.Errorf("unexpected output; got %s, want %s", result, testCase.expected)
-			}
+			require.Equal(t, testCase.expected, result, "unexpected output")
 		})
 	}
 }
@@ -139,9 +124,7 @@ func TestScannableImage(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.imageName, func(t *testing.T) {
 			result := scannableImage(testCase.imageName)
-			if result != testCase.expected {
-				t.Errorf("unexpected output; got %v, want %v", result, testCase.expected)
-			}
+			require.Equal(t, testCase.expected, result, "unexpected output")
 		})
 	}
 }

--- a/pkg/scan/sbom_test.go
+++ b/pkg/scan/sbom_test.go
@@ -7,25 +7,21 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractSBOMsFromTar(t *testing.T) {
 	filePath := "testdata/zarf-package-mattermost-arm64-9.9.1-uds.0.tar.zst"
 
 	tmpDir, err := os.MkdirTemp("", "extract-sbom-*")
-	if err != nil {
-		t.Fatalf("failed to create tmpdir: %s", tmpDir)
-	}
+	require.NoError(t, err, "failed to create tmpdir: %s", tmpDir)
 	defer os.RemoveAll(tmpDir)
 
 	refs, err := ExtractSBOMsFromZarfTarFile(tmpDir, filePath)
-	if err != nil {
-		t.Fatalf("Failed to extract images from tar: %v", err)
-	}
+	require.NoError(t, err, "failed to extract images from tar: %v", err)
 
-	if len(refs) == 0 {
-		t.Fatal("Expected non-empty images, got empty")
-	}
+	require.NotEmpty(t, refs, "expected non-empty images, got empty")
 
 	expectedImageNameFromSBOM := []string{
 		"docker.io/appropriate/curl:latest",
@@ -35,24 +31,17 @@ func TestExtractSBOMsFromTar(t *testing.T) {
 		found := false
 		for _, ref := range refs {
 			actualRef, ok := ref.(*cyclonedxSBOMScannable)
-			if !ok {
-				t.Errorf("expected ref to be a cyclonedxSBOMRef")
-				continue
-			}
+			require.True(t, ok, "expected ref to be a cuclonedxSBOMRef")
 
 			if actualRef.ArtifactName == sbomName {
 				found = true
-				t.Logf("Found expected image: %s", sbomName)
+				t.Logf("found expected image: %s", sbomName)
 
-				if actualRef.SBOMFile == "" {
-					t.Error("got an empty sbomfile, this will not be scannable by trivy")
-				}
+				require.NotEmpty(t, actualRef.SBOMFile, "got an empty sbomfile, this will not be scannable by trivy")
 				break
 			}
 		}
-		if !found {
-			t.Errorf("Expected image not found: %s", sbomName)
-		}
+		require.True(t, found, "expected image not found: %s", sbomName)
 	}
 }
 
@@ -64,9 +53,8 @@ func (f *faultyReader) Read(p []byte) (n int, err error) {
 
 func TestExtractSBOMImageRefsFromReader_FaultyReader(t *testing.T) {
 	_, err := extractSBOMImageRefsFromReader("", &faultyReader{})
-	if err == nil || !strings.Contains(err.Error(), "failed to read header in sbom tar") {
-		t.Errorf("expected header read error, got: %v", err)
-	}
+	require.Error(t, err, "expected header read error, got none")
+	require.ErrorContains(t, err, "failed to read header in sbom tar")
 }
 
 func TestExtractSBOMImageRefsFromReader_InvalidSBOMConversion(t *testing.T) {
@@ -74,25 +62,21 @@ func TestExtractSBOMImageRefsFromReader_InvalidSBOMConversion(t *testing.T) {
 	tw := tar.NewWriter(buf)
 	data := []byte(`invalid json`)
 
-	if err := tw.WriteHeader(&tar.Header{Name: "test.json", Size: int64(len(data))}); err != nil {
-		t.Fatalf("failed to write tar header: %v", err)
-	}
-	if _, err := tw.Write(data); err != nil {
-		t.Fatalf("failed to write tar content: %v", err)
-	}
-	tw.Close()
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "test.json", Size: int64(len(data))}), "failed to write tar header")
 
-	_, err := extractSBOMImageRefsFromReader("", bytes.NewReader(buf.Bytes()))
-	if err == nil {
-		t.Errorf("expected conversion error, got: %v", err)
-	}
+	_, err := tw.Write(data)
+	require.NoError(t, err, "failed to write tar")
+
+	require.NoError(t, tw.Close(), "failed to close tar writer")
+
+	_, err = extractSBOMImageRefsFromReader("", bytes.NewReader(buf.Bytes()))
+	require.Error(t, err, "expected conversion error, got none")
 }
 
 func TestExtractSBOMsFromZarfTarFile(t *testing.T) {
 	_, err := ExtractSBOMsFromZarfTarFile("", "nonexistent.tar")
-	if err == nil || !strings.Contains(err.Error(), "failed to open tar file") {
-		t.Errorf("expected open file error, got: %v", err)
-	}
+	require.Error(t, err, "expected open file error, got none")
+	require.ErrorContains(t, err, "failed to open tar file")
 }
 
 func TestConvertToCyclonedxFormat(t *testing.T) {
@@ -101,14 +85,12 @@ func TestConvertToCyclonedxFormat(t *testing.T) {
 
 	// reader that returns faulty data
 	_, err := convertToCyclonedxFormat(header, &faultyReader{}, "")
-	if err == nil || !strings.Contains(err.Error(), "failed to read sbom from tar") {
-		t.Errorf("expected read error, got: %v", err)
-	}
+	require.Error(t, err, "expected read error, got none")
+	require.ErrorContains(t, err, "failed to read sbom from tar")
 
 	// encoding error by passing invalid sbom data
 	sbomReader := strings.NewReader(`invalid sbom data`)
 	_, err = convertToCyclonedxFormat(header, sbomReader, "")
-	if err == nil || !strings.Contains(err.Error(), "failed to convert sbom format") {
-		t.Errorf("expected sbom conversion error, got: %v", err)
-	}
+	require.Error(t, err, "expected sbom conversion error, got none")
+	require.ErrorContains(t, err, "failed to convert sbom format")
 }

--- a/pkg/scan/scan_factory.go
+++ b/pkg/scan/scan_factory.go
@@ -2,11 +2,14 @@ package scan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/defenseunicorns/uds-security-hub/pkg/types"
 )
+
+var errEmpty = errors.New("org, packageName, and tag are required for remote scanning")
 
 // ScannerFactoryImpl is the implementation of the ScannerFactory interface.
 type ScannerFactoryImpl struct{}
@@ -24,7 +27,7 @@ func (sf *ScannerFactoryImpl) CreateScanner(
 	}
 
 	if org == "" || packageName == "" || tag == "" {
-		return nil, fmt.Errorf("org, packageName, and tag are required for remote scanning")
+		return nil, fmt.Errorf("%w", errEmpty)
 	}
 
 	return NewRemotePackageScanner(

--- a/pkg/scan/scan_factory_test.go
+++ b/pkg/scan/scan_factory_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 // MockPackageScanner is a mock implementation of the PackageScanner interface.
@@ -22,12 +22,8 @@ func TestCreateScanner_LocalPackage(t *testing.T) {
 	packagePath := "/path/to/package"
 
 	scanner, err := sf.CreateScanner(context.Background(), logger, "", "", "", packagePath, "", nil, RootFSScannerType)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if scanner == nil {
-		t.Fatalf("expected non-nil scanner, got nil")
-	}
+	require.NoError(t, err, "expected no error, got %v", err)
+	require.NotNil(t, scanner, "expected non-nil scanner, got nil")
 }
 
 func TestCreateScanner_RemotePackage(t *testing.T) {
@@ -37,12 +33,8 @@ func TestCreateScanner_RemotePackage(t *testing.T) {
 	tag := "latest"
 
 	scanner, err := sf.CreateScanner(context.Background(), nil, org, packageName, tag, "", "", nil, RootFSScannerType)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if scanner == nil {
-		t.Fatalf("expected non-nil scanner, got nil")
-	}
+	require.NoError(t, err, "expected no error, got %v", err)
+	require.NotNil(t, scanner, "expected non-nil scanner, got nil")
 }
 
 func TestCreateScanner_MissingParameters(t *testing.T) {
@@ -50,7 +42,5 @@ func TestCreateScanner_MissingParameters(t *testing.T) {
 
 	_, err := sf.CreateScanner(context.Background(), nil, "", "", "", "", "", nil, RootFSScannerType)
 	expectedErr := "org, packageName, and tag are required for remote scanning"
-	if diff := cmp.Diff(expectedErr, err.Error()); diff != "" {
-		t.Errorf("unexpected error (-want +got):\n%s", diff)
-	}
+	require.Equal(t, expectedErr, err.Error(), "unexpected error (-want +got)")
 }

--- a/pkg/scan/scan_factory_test.go
+++ b/pkg/scan/scan_factory_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,5 +43,7 @@ func TestCreateScanner_MissingParameters(t *testing.T) {
 
 	_, err := sf.CreateScanner(context.Background(), nil, "", "", "", "", "", nil, RootFSScannerType)
 	expectedErr := "org, packageName, and tag are required for remote scanning"
-	require.Equal(t, expectedErr, err.Error(), "unexpected error (-want +got)")
+
+	diff := cmp.Diff(expectedErr, err.Error())
+	require.Empty(t, diff)
 }

--- a/pkg/scan/trivy_scannable_test.go
+++ b/pkg/scan/trivy_scannable_test.go
@@ -2,6 +2,8 @@ package scan
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestScannerType_String(t *testing.T) {
@@ -16,9 +18,8 @@ func TestScannerType_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.scanner.String(); got != tt.expected {
-				t.Errorf("ScannerType.String() = %v, want %v", got, tt.expected)
-			}
+			got := tt.scanner.String()
+			require.Equal(t, tt.expected, got, "ScannerType.Type() mismatch (-got +want):\n%s")
 		})
 	}
 }
@@ -38,11 +39,11 @@ func TestScannerType_Set(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var scanner ScannerType
 			err := scanner.Set(tt.input)
-			if tt.expectErr && err == nil {
-				t.Errorf("ScannerType.Set() error = %v, wantErr %v", err, tt.expectErr)
-			}
-			if !tt.expectErr && scanner.String() != tt.input {
-				t.Errorf("Expected scanner to be set to %v, but got %v", tt.input, scanner.String())
+			if tt.expectErr {
+				require.Error(t, err, "expected an error but got none")
+			} else {
+				require.NoError(t, err, "expected no error but got one")
+				require.Equal(t, tt.input, scanner.String(), "expected scanner to be set to %v, but got %v", tt.input, scanner.String())
 			}
 		})
 	}
@@ -52,7 +53,6 @@ func TestScannerType_Type(t *testing.T) {
 	scanner := ScannerType("any")
 	expectedType := "ScannerType"
 
-	if got := scanner.Type(); got != expectedType {
-		t.Errorf("ScannerType.Type() = %v, want %v", got, expectedType)
-	}
+	got := scanner.Type()
+	require.Equal(t, expectedType, got, "ScannerType.Type() mismatch (-got +want):\n%s")
 }


### PR DESCRIPTION
Refactored to use `github.com/stretchr/testify/require`:

- e2e_test.go
- local_scan_test.go
- rootfs_test.go
- sbom_test.go
- scan_factory_test.go
- trivy_scannable_test.go

Refactored to use variable for error handling:

- scan_factory.go